### PR TITLE
Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,15 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 
 include_directories(AFTER SYSTEM include)
 set(LIBRARY_FILES src/pico.c include/pico_errno.h include/pico_defs.h)
-add_library(libcpico ${LIBRARY_FILES})
+add_library(cpico_static STATIC ${LIBRARY_FILES})
+add_library(cpico_shared SHARED ${LIBRARY_FILES})
+set_property( TARGET cpico_static PROPERTY POSITION_INDEPENDENT_CODE 1 )
+if( UNIX )
+    set_target_properties(cpico_shared PROPERTIES OUTPUT_NAME cpico)
+    set_target_properties(cpico_static PROPERTIES OUTPUT_NAME cpico)
+endif ( UNIX )
 add_executable(cpico src/main.c)
-target_link_libraries(cpico libcpico)
+target_link_libraries(cpico cpico_static)
 
 # Generate API documentation using Doxygen.
 find_package(Doxygen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Configuration file to build cpico.
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 2.8)
 project(cpico)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 
 include_directories(AFTER SYSTEM include)
 set(LIBRARY_FILES src/pico.c include/pico_errno.h include/pico_defs.h)

--- a/include/pico_defs.h
+++ b/include/pico_defs.h
@@ -19,6 +19,9 @@
  * according to those terms.
  */
 
+#ifdef __linux__
+#include <arpa/inet.h>
+#endif //__linux__
 #include "pico_errno.h"
 
 /// Pico file magic number.


### PR DESCRIPTION
Updates to the CMakeLists.txt to produce shared libraries and build on OS X.

This PR fixes a RPATH warning on OS X 10.10.4, but this build error remains:

```
Undefined symbols for architecture x86_64:
  "_MD5_Final", referenced from:
      _pico_get_hash in pico.c.o
  "_MD5_Init", referenced from:
      _pico_get_hash in pico.c.o
  "_MD5_Update", referenced from:
      _pico_get_hash in pico.c.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This _does_ build under Ubuntu 14.04 without errors or warnings.
